### PR TITLE
fix: Update cryoet-data-portal client reqs to >=4.0.0

### DIFF
--- a/overview.ipynb
+++ b/overview.ipynb
@@ -216,8 +216,8 @@
       "Requirement already satisfied: asttokens>=2.1.0 in /Users/kharrington/.album/micromamba/envs/cz_cryoet_mlchallenge/lib/python3.10/site-packages (from stack-data->IPython>=7.7.0->napari-console>=0.0.9->napari) (2.4.1)\n",
       "Requirement already satisfied: pure-eval in /Users/kharrington/.album/micromamba/envs/cz_cryoet_mlchallenge/lib/python3.10/site-packages (from stack-data->IPython>=7.7.0->napari-console>=0.0.9->napari) (0.2.3)\n",
       "Downloading napari-0.5.3-py3-none-any.whl (3.0 MB)\n",
-      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m3.0/3.0 MB\u001b[0m \u001b[31m4.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0ma \u001b[36m0:00:01\u001b[0m\n",
-      "\u001b[?25hUsing cached monai-1.3.2-py3-none-any.whl (1.4 MB)\n",
+      "\u001B[2K   \u001B[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[32m3.0/3.0 MB\u001B[0m \u001B[31m4.0 MB/s\u001B[0m eta \u001B[36m0:00:00\u001B[0ma \u001B[36m0:00:01\u001B[0m\n",
+      "\u001B[?25hUsing cached monai-1.3.2-py3-none-any.whl (1.4 MB)\n",
       "Downloading zarr-2.18.3-py3-none-any.whl (210 kB)\n",
       "Using cached app_model-0.2.8-py3-none-any.whl (64 kB)\n",
       "Using cached appdirs-1.4.4-py2.py3-none-any.whl (9.6 kB)\n",
@@ -294,15 +294,13 @@
       "Using cached sphinxcontrib_qthelp-2.0.0-py3-none-any.whl (88 kB)\n",
       "Using cached mdurl-0.1.2-py3-none-any.whl (10.0 kB)\n",
       "Installing collected packages: snowballstemmer, PyOpenGL, mpmath, heapdict, asciitree, appdirs, wrapt, tzdata, tqdm, toolz, tomli-w, tifffile, tabulate, sympy, sphinxcontrib-serializinghtml, sphinxcontrib-qthelp, sphinxcontrib-jsmath, sphinxcontrib-htmlhelp, sphinxcontrib-devhelp, sphinxcontrib-applehelp, shellingham, scipy, qtpy, pyproject_hooks, pydantic-core, psygnal, Pillow, numcodecs, networkx, napari-plugin-engine, mdurl, locket, lazy-loader, kiwisolver, in-n-out, imagesize, hsluv, fsspec, freetype-py, flexparser, flexcache, filelock, fasteners, docutils, docstring-parser, cloudpickle, click, cachey, annotated-types, alabaster, zarr, vispy, torch, superqt, sphinx, pydantic, pyconify, pooch, pint, partd, pandas, markdown-it-py, imageio, build, scikit-image, rich, pydantic-compat, numpydoc, napari-svg, monai, dask, typer, magicgui, app-model, qtconsole, npe2, napari-console, napari\n",
-      "\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
-      "virtualenv 20.21.0 requires platformdirs<4,>=2.4, but you have platformdirs 4.3.2 which is incompatible.\u001b[0m\u001b[31m\n",
-      "\u001b[0mSuccessfully installed Pillow-10.4.0 PyOpenGL-3.1.7 alabaster-1.0.0 annotated-types-0.7.0 app-model-0.2.8 appdirs-1.4.4 asciitree-0.3.3 build-1.2.2 cachey-0.2.1 click-8.1.7 cloudpickle-3.0.0 dask-2024.8.2 docstring-parser-0.16 docutils-0.21.2 fasteners-0.19 filelock-3.16.0 flexcache-0.3 flexparser-0.3.1 freetype-py-2.5.1 fsspec-2024.9.0 heapdict-1.0.1 hsluv-5.0.4 imageio-2.35.1 imagesize-1.4.1 in-n-out-0.2.1 kiwisolver-1.4.7 lazy-loader-0.4 locket-1.0.0 magicgui-0.9.1 markdown-it-py-3.0.0 mdurl-0.1.2 monai-1.3.2 mpmath-1.3.0 napari-0.5.3 napari-console-0.0.9 napari-plugin-engine-0.2.0 napari-svg-0.2.0 networkx-3.3 npe2-0.7.7 numcodecs-0.13.0 numpydoc-1.8.0 pandas-2.2.2 partd-1.4.2 pint-0.24.3 pooch-1.8.2 psygnal-0.11.1 pyconify-0.1.6 pydantic-2.9.1 pydantic-compat-0.1.2 pydantic-core-2.23.3 pyproject_hooks-1.1.0 qtconsole-5.6.0 qtpy-2.4.1 rich-13.8.1 scikit-image-0.24.0 scipy-1.14.1 shellingham-1.5.4 snowballstemmer-2.2.0 sphinx-8.0.2 sphinxcontrib-applehelp-2.0.0 sphinxcontrib-devhelp-2.0.0 sphinxcontrib-htmlhelp-2.1.0 sphinxcontrib-jsmath-1.0.1 sphinxcontrib-qthelp-2.0.0 sphinxcontrib-serializinghtml-2.0.0 superqt-0.6.7 sympy-1.13.2 tabulate-0.9.0 tifffile-2024.8.30 tomli-w-1.0.0 toolz-0.12.1 torch-2.2.2 tqdm-4.66.5 typer-0.12.5 tzdata-2024.1 vispy-0.14.3 wrapt-1.16.0 zarr-2.18.3\n"
+      "\u001B[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
+      "virtualenv 20.21.0 requires platformdirs<4,>=2.4, but you have platformdirs 4.3.2 which is incompatible.\u001B[0m\u001B[31m\n",
+      "\u001B[0mSuccessfully installed Pillow-10.4.0 PyOpenGL-3.1.7 alabaster-1.0.0 annotated-types-0.7.0 app-model-0.2.8 appdirs-1.4.4 asciitree-0.3.3 build-1.2.2 cachey-0.2.1 click-8.1.7 cloudpickle-3.0.0 dask-2024.8.2 docstring-parser-0.16 docutils-0.21.2 fasteners-0.19 filelock-3.16.0 flexcache-0.3 flexparser-0.3.1 freetype-py-2.5.1 fsspec-2024.9.0 heapdict-1.0.1 hsluv-5.0.4 imageio-2.35.1 imagesize-1.4.1 in-n-out-0.2.1 kiwisolver-1.4.7 lazy-loader-0.4 locket-1.0.0 magicgui-0.9.1 markdown-it-py-3.0.0 mdurl-0.1.2 monai-1.3.2 mpmath-1.3.0 napari-0.5.3 napari-console-0.0.9 napari-plugin-engine-0.2.0 napari-svg-0.2.0 networkx-3.3 npe2-0.7.7 numcodecs-0.13.0 numpydoc-1.8.0 pandas-2.2.2 partd-1.4.2 pint-0.24.3 pooch-1.8.2 psygnal-0.11.1 pyconify-0.1.6 pydantic-2.9.1 pydantic-compat-0.1.2 pydantic-core-2.23.3 pyproject_hooks-1.1.0 qtconsole-5.6.0 qtpy-2.4.1 rich-13.8.1 scikit-image-0.24.0 scipy-1.14.1 shellingham-1.5.4 snowballstemmer-2.2.0 sphinx-8.0.2 sphinxcontrib-applehelp-2.0.0 sphinxcontrib-devhelp-2.0.0 sphinxcontrib-htmlhelp-2.1.0 sphinxcontrib-jsmath-1.0.1 sphinxcontrib-qthelp-2.0.0 sphinxcontrib-serializinghtml-2.0.0 superqt-0.6.7 sympy-1.13.2 tabulate-0.9.0 tifffile-2024.8.30 tomli-w-1.0.0 toolz-0.12.1 torch-2.2.2 tqdm-4.66.5 typer-0.12.5 tzdata-2024.1 vispy-0.14.3 wrapt-1.16.0 zarr-2.18.3\n"
      ]
     }
    ],
-   "source": [
-    "!pip install napari monai zarr \"numpy<2\" cryoet-data-portal==3.0.3 s3fs trimesh ome-zarr scikit-image trimesh pyside2"
-   ]
+   "source": "!pip install napari monai zarr \"numpy<2\" cryoet-data-portal==4.0.0 s3fs trimesh ome-zarr scikit-image trimesh pyside2"
   },
   {
    "cell_type": "code",
@@ -322,12 +320,12 @@
       "  Cloning https://github.com/copick/copick-utils.git to /private/var/folders/z0/_bcy172x6xg12j6wylfkhc_h0000gq/T/pip-req-build-we5npo_q\n",
       "  Running command git clone --filter=blob:none --quiet https://github.com/copick/copick-utils.git /private/var/folders/z0/_bcy172x6xg12j6wylfkhc_h0000gq/T/pip-req-build-we5npo_q\n",
       "  Resolved https://github.com/copick/copick-utils.git to commit a21f5f289d54844287f512da36045e66c9d10f09\n",
-      "  Installing build dependencies ... \u001b[?25ldone\n",
-      "\u001b[?25h  Getting requirements to build wheel ... \u001b[?25ldone\n",
-      "\u001b[?25h  Preparing metadata (pyproject.toml) ... \u001b[?25ldone\n",
-      "\u001b[?25hBuilding wheels for collected packages: copick-utils\n",
-      "  Building wheel for copick-utils (pyproject.toml) ... \u001b[?25ldone\n",
-      "\u001b[?25h  Created wheel for copick-utils: filename=copick_utils-0.0.1-py3-none-any.whl size=8703 sha256=5f9f9f87b1c8163ba18bb51034f3be7b7e70ae09b3f283e51111de60ed7dc5ce\n",
+      "  Installing build dependencies ... \u001B[?25ldone\n",
+      "\u001B[?25h  Getting requirements to build wheel ... \u001B[?25ldone\n",
+      "\u001B[?25h  Preparing metadata (pyproject.toml) ... \u001B[?25ldone\n",
+      "\u001B[?25hBuilding wheels for collected packages: copick-utils\n",
+      "  Building wheel for copick-utils (pyproject.toml) ... \u001B[?25ldone\n",
+      "\u001B[?25h  Created wheel for copick-utils: filename=copick_utils-0.0.1-py3-none-any.whl size=8703 sha256=5f9f9f87b1c8163ba18bb51034f3be7b7e70ae09b3f283e51111de60ed7dc5ce\n",
       "  Stored in directory: /private/var/folders/z0/_bcy172x6xg12j6wylfkhc_h0000gq/T/pip-ephem-wheel-cache-b6yw7zz1/wheels/a6/a7/39/72b64bd4eecf4d57d5d4e1fcec96fdb0cd49ae7dbb336fcc4c\n",
       "Successfully built copick-utils\n",
       "Installing collected packages: copick-utils\n",
@@ -344,15 +342,15 @@
       "Successfully installed morphospaces-0.0.4\n",
       "Collecting https://github.com/copick/copick-torch.git\n",
       "  Downloading https://github.com/copick/copick-torch.git\n",
-      "\u001b[2K     \u001b[32m-\u001b[0m \u001b[32m276.6 kB\u001b[0m \u001b[31m6.6 MB/s\u001b[0m \u001b[33m0:00:00\u001b[0m\n",
-      "\u001b[?25h\u001b[31m  ERROR: Cannot unpack file /private/var/folders/z0/_bcy172x6xg12j6wylfkhc_h0000gq/T/pip-unpack-j4tbf0d4/copick-torch.git (downloaded from /private/var/folders/z0/_bcy172x6xg12j6wylfkhc_h0000gq/T/pip-req-build-vzcxxv97, content-type: text/html; charset=utf-8); cannot detect archive format\u001b[0m\u001b[31m\n",
-      "\u001b[0m\u001b[31mERROR: Cannot determine archive format of /private/var/folders/z0/_bcy172x6xg12j6wylfkhc_h0000gq/T/pip-req-build-vzcxxv97\u001b[0m\u001b[31m\n",
-      "\u001b[0m"
+      "\u001B[2K     \u001B[32m-\u001B[0m \u001B[32m276.6 kB\u001B[0m \u001B[31m6.6 MB/s\u001B[0m \u001B[33m0:00:00\u001B[0m\n",
+      "\u001B[?25h\u001B[31m  ERROR: Cannot unpack file /private/var/folders/z0/_bcy172x6xg12j6wylfkhc_h0000gq/T/pip-unpack-j4tbf0d4/copick-torch.git (downloaded from /private/var/folders/z0/_bcy172x6xg12j6wylfkhc_h0000gq/T/pip-req-build-vzcxxv97, content-type: text/html; charset=utf-8); cannot detect archive format\u001B[0m\u001B[31m\n",
+      "\u001B[0m\u001B[31mERROR: Cannot determine archive format of /private/var/folders/z0/_bcy172x6xg12j6wylfkhc_h0000gq/T/pip-req-build-vzcxxv97\u001B[0m\u001B[31m\n",
+      "\u001B[0m"
      ]
     }
    ],
    "source": [
-    "!pip install --no-deps copick\n",
+    "!pip install --no-deps copick>=0.6.0\n",
     "!pip install --no-deps git+https://github.com/copick/copick-utils.git\n",
     "!pip install --no-deps h5py\n",
     "!pip install --no-deps morphospaces\n",

--- a/tomotwin_picking_notebook/tomotwin_copick_environment.yml
+++ b/tomotwin_picking_notebook/tomotwin_copick_environment.yml
@@ -549,8 +549,8 @@ dependencies:
   - zstd=1.5.6=ha6fb4c9_0
   - pip:
       - absl-py==2.1.0
-      - copick==0.5.6
-      - cryoet-data-portal==3.0.3
+      - copick==0.6.0
+      - cryoet-data-portal==4.0.0
       - grpcio==1.66.2
       - pandas==2.0.0
       - protobuf==5.28.2


### PR DESCRIPTION
Some notebooks pin `cryoet-data-portal` to 3.0.3, a version pre-APIv2 migration. This leads to failures when attempting to use `copick>=0.6` (which relies on data portal APIv2). 

This PR updates the two offending notebooks.

Adressing #7 